### PR TITLE
Implement API key auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@ A simple Express service that generates presigned download URLs for DigitalOcean
    - `SPACES_ENDPOINT`
    - `REGION`
    - `BUCKET_NAME`
+   - `API_KEY` (required API key for requests)
    - `PORT` (optional, defaults to `3000`)
 3. Start the server:
    ```bash
    npm start
+   ```
+
+4. Make a request:
+   ```bash
+   curl -X POST http://localhost:$PORT/presign \
+     -H "Content-Type: application/json" \
+     -H "x-api-key: $API_KEY" \
+     -d '{"key":"file.txt"}'
    ```

--- a/index.js
+++ b/index.js
@@ -3,14 +3,39 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import dotenv from 'dotenv';
 dotenv.config();
-const { ACCESS_KEY_ID, SECRET_ACCESS_KEY, SPACES_ENDPOINT, REGION, BUCKET_NAME, PORT = 3000 } = process.env;
-if (!ACCESS_KEY_ID || !SECRET_ACCESS_KEY || !SPACES_ENDPOINT || !REGION || !BUCKET_NAME) {
+// Read configuration including the expected API key
+const {
+  ACCESS_KEY_ID,
+  SECRET_ACCESS_KEY,
+  SPACES_ENDPOINT,
+  REGION,
+  BUCKET_NAME,
+  PORT = 3000,
+  API_KEY, // expected API key value
+} = process.env;
+// Exit if any required environment variable (including API_KEY) is missing
+if (
+  !ACCESS_KEY_ID ||
+  !SECRET_ACCESS_KEY ||
+  !SPACES_ENDPOINT ||
+  !REGION ||
+  !BUCKET_NAME ||
+  !API_KEY
+) {
   console.error('Missing required environment variables');
   process.exit(1);
 }
 const s3 = new S3Client({ region: REGION, endpoint: SPACES_ENDPOINT, credentials: { accessKeyId: ACCESS_KEY_ID, secretAccessKey: SECRET_ACCESS_KEY } });
 const app = express();
 app.use(express.json());
+// Middleware to check the x-api-key header
+app.use((req, res, next) => {
+  const key = req.header('x-api-key');
+  if (!key || key !== API_KEY) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+});
 app.post('/presign', async (req, res) => {
   const { key, expiresIn = 3600 } = req.body;
   if (!key) return res.status(400).json({ error: 'Missing "key"' });


### PR DESCRIPTION
## Summary
- enforce presence of API_KEY environment variable
- add middleware checking `x-api-key` header
- document new API key requirement and sample curl request

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`
- `node index.js` *(fails: Missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68528133e00c832ba8f6d83c95d771e1