### PR TITLE
Add minimal tests and update instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENT instructions
+
+This repository contains a small Express service for generating presigned URLs for DigitalOcean Spaces.
+
+## Guidelines
+
+- Keep the code in `index.js` concise and use the existing code style.
+- After making changes, run `npm test` to execute the test suite.
+- The server expects several environment variables. See `README.md` for details.

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ if (
 }
 const s3 = new S3Client({ region: REGION, endpoint: SPACES_ENDPOINT, credentials: { accessKeyId: ACCESS_KEY_ID, secretAccessKey: SECRET_ACCESS_KEY } });
 const app = express();
+app.set('trust proxy', true);
 app.use(express.json());
 // Apply global rate limiting to protect the API
 const limiter = rateLimit({
@@ -97,4 +98,8 @@ app.post('/presign', async (req, res) => {
     res.status(500).json({ error: 'Error generating presigned URL' });
   }
 });
-app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+}
+
+export default app;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.379.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+process.env.ACCESS_KEY_ID = 'x';
+process.env.SECRET_ACCESS_KEY = 'x';
+process.env.SPACES_ENDPOINT = 'https://example.com';
+process.env.REGION = 'us-east-1';
+process.env.API_KEY = 'testkey';
+process.env.NODE_ENV = 'test';
+
+const { default: app } = await import('../index.js');
+
+test('trust proxy is enabled', () => {
+  assert.equal(app.get('trust proxy'), true);
+});
+
+test('POST /presign requires API key and key', async () => {
+  const server = app.listen(0);
+  const url = `http://127.0.0.1:${server.address().port}`;
+
+  let res = await fetch(`${url}/presign`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+  assert.equal(res.status, 401);
+
+  res = await fetch(`${url}/presign`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': 'testkey'
+    },
+    body: '{}'
+  });
+  assert.equal(res.status, 400);
+  server.close();
+});


### PR DESCRIPTION
## Summary
- update AGENTS instructions
- export the Express app for tests
- run server only when not under test
- add Node test verifying trust proxy and auth

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529f8fcf94832b8aa5ac4bf617ea7f