### PR TITLE
Add key in presigned response

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ app.post('/presign', async (req, res) => {
     const url = await getSignedUrl(s3, command, {
       expiresIn: Number(expiresIn) || 3600,
     });
-    res.json({ url });
+    res.json({ url, key });
   } catch (error) {
     console.error('Presign error:', error);
     res.status(500).json({ error: 'Error generating presigned URL' });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,3 +32,22 @@ test('POST /presign requires API key and key', async () => {
   assert.equal(res.status, 400);
   server.close();
 });
+
+test('POST /presign returns url and key', async () => {
+  const server = app.listen(0);
+  const url = `http://127.0.0.1:${server.address().port}`;
+
+  const res = await fetch(`${url}/presign`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': 'testkey'
+    },
+    body: JSON.stringify({ key: 'file.txt', bucket: 'b' })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(data.url.includes('https://'));
+  assert.equal(data.key, 'file.txt');
+  server.close();
+});


### PR DESCRIPTION
## Summary
- include the requested key in `/presign` response
- test that presigned response contains the key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ae5b71b8832ba39d4e27ffae3f09